### PR TITLE
consistent number of decimal places shown in forest plot

### DIFF
--- a/R/forest.R
+++ b/R/forest.R
@@ -74,11 +74,11 @@ forest <- function(model,
                                     samples_sum[[grouping]])
   # Create text intervals
   samples_sum[["Interval"]] <- paste0(
-    round(samples_sum[["Estimate"]], digits),
+    format(round(samples_sum[["Estimate"]], digits), nsmall = digits),
     " [",
-    round(samples_sum[[lwr]], digits),
+    format(round(samples_sum[[lwr]], digits), nsmall = digits),
     ", ",
-    round(samples_sum[[upr]], digits), "]"
+    format(round(samples_sum[[upr]], digits), nsmall = digits), "]"
   )
   # Order effects
   if (sort) samples_sum <- dplyr::arrange_(samples_sum, "type", "Parameter", "Estimate")


### PR DESCRIPTION
Rounding of decimal places in forest() previously left some estimates with different numbers of decimal places, e.g., "0.13 [0.11, 0.15]" vs. "0.13 [0.1, 0.16]", which disrupted the text columns in the plot. This was corrected.